### PR TITLE
feat: implement SQLite db and add command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /coverage.txt
 
 /vendor
+*.db

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/negadras/tada/cmd/db"
+	"github.com/spf13/cobra"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func newAddTadaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add [description]",
+		Short: "Add a todo task",
+		Long: `Add a new todo task with the specified description and priority.
+Priority levels:
+  low, l     - Low priority (default)
+  medium, m  - Medium priority
+  high, h    - High priority`,
+		Example: `  # Add a high priority task
+  tada add "Fix the login bug" --priority high
+  
+  # Add with short priority flag
+  tada add "Write documentation" -p medium
+  
+  # Add low priority task (default)
+  tada add "Clean up code"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			todoDB, err := getTodoDB()
+			if err != nil {
+				return fmt.Errorf("failed to open database: %w", err)
+			}
+			defer todoDB.Close()
+
+			description := strings.TrimSpace(args[0])
+			if description == "" {
+				return fmt.Errorf("task description cannot be empty")
+			}
+
+			priorityFlag, _ := cmd.Flags().GetString("priority")
+			priority, err := parsePriority(priorityFlag)
+			if err != nil {
+				return fmt.Errorf("invalid priority '%s':%w", priorityFlag, err)
+			}
+
+			todo, err := todoDB.CreateTodo(description, priority)
+			if err != nil {
+				return fmt.Errorf("failed to create todo: %w", err)
+			}
+
+			cmd.Printf("✅ Created todo #%d: %s\n", todo.ID, todo.Description)
+			cmd.Printf("   Priority: %s\n", priority.String())
+			cmd.Printf("   Status: %s\n", todo.Status.String())
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("priority", "p", "medium", "Priority level (low/l, medium/m, high/h)")
+	return cmd
+}
+
+// getTodoDB initializes the database connection with proper path handling
+func getTodoDB() (*db.TodoDB, error) {
+	// Get user's home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	// Create .tada directory if it doesn't exist
+	tadaDir := filepath.Join(homeDir, ".tada")
+	if err := os.MkdirAll(tadaDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create .tada directory: %w", err)
+	}
+
+	// Database file path
+	dbPath := filepath.Join(tadaDir, "todos.db")
+
+	return db.NewTodoDB(dbPath)
+}
+
+// parsePriority converts string priority to Priority enum
+func parsePriority(priorityStr string) (db.Priority, error) {
+	switch strings.ToLower(strings.TrimSpace(priorityStr)) {
+	case "low", "l", "1":
+		return db.Low, nil
+	case "medium", "m", "2":
+		return db.Medium, nil
+	case "high", "h", "3":
+		return db.High, nil
+	default:
+		return db.Medium, fmt.Errorf("must be one of: low, medium, high (or l, m, h)")
+	}
+}

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -1,0 +1,244 @@
+package db
+
+import (
+	"database/sql"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type Priority int
+
+const (
+	Low Priority = iota + 1
+	Medium
+	High
+)
+
+func (p Priority) String() string {
+	switch p {
+	case Low:
+		return "LOW"
+	case Medium:
+		return "MEDIUM"
+	case High:
+		return "HIGH"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+type Status int
+
+const (
+	Open Status = iota + 1
+	Done
+)
+
+func (s Status) String() string {
+	switch s {
+	case Open:
+		return "OPEN"
+	case Done:
+		return "DONE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+type Todo struct {
+	ID          int        `json:"id"`
+	Description string     `json:"description"`
+	Priority    Priority   `json:"priority"`
+	Status      Status     `json:"status"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"` // Only set when status = Done
+}
+
+func (t *Todo) Age() time.Duration {
+	return time.Since(t.CreatedAt)
+}
+
+func (t *Todo) CompletedAge() *time.Duration {
+	if t.CompletedAt == nil {
+		return nil
+	}
+
+	age := time.Since(*t.CompletedAt)
+	return &age
+}
+
+// Database schema
+const createTableSQL = `
+CREATE TABLE IF NOT EXISTS todos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    description TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 2 CHECK(priority IN (1, 2, 3)),
+    status INTEGER NOT NULL DEFAULT 1 CHECK(status IN (1, 2)),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME NULL
+);
+
+-- Index for common queries
+CREATE INDEX IF NOT EXISTS idx_todos_status ON todos(status);
+CREATE INDEX IF NOT EXISTS idx_todos_priority ON todos(priority);
+CREATE INDEX IF NOT EXISTS idx_todos_created_at ON todos(created_at);
+`
+
+type TodoDB struct {
+	db *sql.DB
+}
+
+func NewTodoDB(dbPath string) (*TodoDB, error) {
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create table and indexes
+	if _, err := db.Exec(createTableSQL); err != nil {
+		return nil, err
+	}
+
+	return &TodoDB{db: db}, nil
+}
+
+func (tdb *TodoDB) CreateTodo(description string, priority Priority) (*Todo, error) {
+	result, err := tdb.db.Exec(`
+	  INSERT INTO todos (description, priority)
+	  VALUES (?, ?)
+	`, description, int(priority))
+
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	return tdb.GetTodo(int(id))
+}
+
+func (tdb *TodoDB) GetTodo(id int) (*Todo, error) {
+	row := tdb.db.QueryRow(`
+	SELECT id, description, priority, status, created_at, updated_at, completed_at
+	FROM todos WHERE id = ?
+	`, id)
+
+	todo := &Todo{}
+	var completedAt sql.NullTime
+
+	err := row.Scan(
+		&todo.ID, &todo.Description, &todo.Priority, &todo.Status,
+		&todo.CreatedAt, &todo.UpdatedAt, &completedAt,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if completedAt.Valid {
+		todo.CompletedAt = &completedAt.Time
+	}
+
+	return todo, nil
+}
+
+func (tdb *TodoDB) ListTodos(status *Status, priority *Priority) ([]*Todo, error) {
+	query := `
+		SELECT id, description, priority, status, created_at, updated_at, completed_at
+		FROM todos WHERE 1=1
+	`
+	args := []interface{}{}
+
+	if status != nil {
+		query += " AND status = ?"
+		args = append(args, int(*status))
+	}
+
+	if priority != nil {
+		query += " AND priority = ?"
+		args = append(args, int(*priority))
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	rows, err := tdb.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var todos []*Todo
+	for rows.Next() {
+		todo := &Todo{}
+		var completedAt sql.NullTime
+
+		err := rows.Scan(
+			&todo.ID, &todo.Description, &todo.Priority, &todo.Status,
+			&todo.CreatedAt, &todo.UpdatedAt, &completedAt,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if completedAt.Valid {
+			todo.CompletedAt = &completedAt.Time
+		}
+
+		todos = append(todos, todo)
+	}
+
+	return todos, rows.Err()
+}
+
+func (tdb *TodoDB) UpdateTodoStatus(id int, status Status) error {
+	var completedAt interface{}
+	if status == Done {
+		completedAt = time.Now()
+	} else {
+		completedAt = nil
+	}
+
+	_, err := tdb.db.Exec(`
+		UPDATE todos 
+		SET status = ?, completed_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, int(status), completedAt, id)
+
+	return err
+}
+
+func (tdb *TodoDB) UpdateTodoPriority(id int, priority Priority) error {
+	_, err := tdb.db.Exec(`
+		UPDATE todos 
+		SET priority = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, int(priority), id)
+
+	return err
+}
+
+func (tdb *TodoDB) UpdateTodoDescription(id int, description string) error {
+	_, err := tdb.db.Exec(`
+		UPDATE todos 
+		SET description = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, description, id)
+
+	return err
+}
+
+func (tdb *TodoDB) DeleteTodo(id int) error {
+	_, err := tdb.db.Exec("DELETE FROM todos WHERE id = ?", id)
+	return err
+}
+
+func (tdb *TodoDB) Close() error {
+	return tdb.db.Close()
+}

--- a/cmd/quote.go
+++ b/cmd/quote.go
@@ -8,18 +8,19 @@ import (
 // Quote when the quote command is used it should return randomly a quote from the list
 // should this quote be in a json so that we can manage them edit/update/delete
 var Quote = []string{
-	"Shower thoughts only work when you put in the work.",
-	"Take the time it takes so it takes less time.",
-	"Don't go out and try to find the quotes, they should come to you.",
-	"Nobody cares how hard you worked, only the results.",
-	"If you want everything to be familiar, you will never learn anything new.",
-	"Do or do not. There is no try.",
+	"🚿 Shower thoughts only work when you put in the work.",
+	"⏰ Take the time it takes so it takes less time.",
+	"🌱 Don't go out and try to find the quotes, they should come to you.",
+	"🏆 Nobody cares how hard you worked, only the results.",
+	"💡 If you want everything to be familiar, you will never learn anything new.",
+	"✨ Do or do not. There is no try.",
+	"⚡ Inspiration is perishable. Act on it immediately",
 }
 
 func newQuoteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "quote",
-		Short: "Tada random quote from our list",
+		Short: "Get a random quote from our list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			randomQuote := Quote[rand.Intn(len(Quote))]
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ todo list, edit, close ...`,
 	}
 
 	cmd.AddCommand(newQuoteCommand())
+	cmd.AddCommand(newAddTadaCommand())
 
 	return cmd
 }

--- a/docs/tada-cli-plan.md
+++ b/docs/tada-cli-plan.md
@@ -4,6 +4,10 @@
     -  [ ] delete task
     -  [ ] edit task
     -  [ ] get task
+    -  [ ] report bug (example CLI that does that was 🤔)
+    -  [ ] task need to have type (person, job, ... ) and user can add type, what should be default
+- [ ] possible features
+  - [ ] creating issues for tada at `negadras/tada` or report it in #bonial-cli Slack channel `gh issue create`
 
 ## Data Storage 
 - [ ] set up a SQLite database

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-sqlite3 v1.14.28 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stg
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=


### PR DESCRIPTION
* feat(db): implement SQLite database with todo CRUD operations

- Add TodoDB struct with SQLite3 backend
- Implement Priority and Status enums with String() methods
- Add CRUD operations for todos
- Include database schema with constraints and indexes
- Support age calculation and completion tracking

* feat(cmd): implement 'add' command for todo creation

- Add newAddTadaCommand with flexible priority parsing
- Store todos in ~/.tada/todos.db with automatic directory creation
- Support short/long priority flags (low/l, medium/m, high/h)
- Include comprehensive error handling and validation
- Add detailed CLI documentation and examples
- Add cli feature note